### PR TITLE
fix: replace time.Sleep with polling helpers in tests

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/wspulse/core v0.2.0 h1:1Tyd2OZ2KMi+qvmf5PKxP7KDzCfT09Jx6KRUrDEXlCg=
 github.com/wspulse/core v0.2.0/go.mod h1:IT/dOeC+Hwh+CT6rI7YVI1CKdVmbd4tbpF6ggztXl8M=
-github.com/wspulse/server v0.3.0 h1:U5VBw/DxotulozvknCnz9+Ykw7TDl0si/jnm48ucZHg=
-github.com/wspulse/server v0.3.0/go.mod h1:BIncijHx5IbPkPCZfO3P5Hye3o2jWWQ352TKMDnkkvU=
+github.com/wspulse/server v0.6.0 h1:oHNY1auxv1bKtNSdB2NmBqYVxjR/I/OD+w/uNsbmHZY=
+github.com/wspulse/server v0.6.0/go.mod h1:BIncijHx5IbPkPCZfO3P5Hye3o2jWWQ352TKMDnkkvU=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/main_test.go
+++ b/main_test.go
@@ -88,6 +88,40 @@ func dialWS(t *testing.T, wsURL string, query string) *websocket.Conn {
 	return conn
 }
 
+// waitForDialFail polls until a WebSocket dial to wsURL fails, indicating
+// the server is no longer accepting connections. It uses a 3-second deadline.
+func waitForDialFail(t *testing.T, wsURL string) {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, _, err := websocket.DefaultDialer.Dial(wsURL+"?id=probe", nil)
+		if err != nil {
+			return // server is down — success
+		}
+		_ = conn.Close()
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for server to stop accepting connections")
+}
+
+// waitForDialSuccess polls until a WebSocket dial to wsURL succeeds,
+// indicating the server is ready. It uses a 3-second deadline.
+func waitForDialSuccess(t *testing.T, wsURL string) {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, _, err := websocket.DefaultDialer.Dial(wsURL+"?id=probe", nil)
+		if err == nil {
+			_ = conn.Close()
+			return // server is up — success
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for server to accept connections")
+}
+
 // ── tests ───────────────────────────────────────────────────────────────────
 
 func TestHealth(t *testing.T) {
@@ -143,8 +177,7 @@ func TestKick(t *testing.T) {
 		t.Fatalf("read: %v", err)
 	}
 
-	// Wait for server to register the connection in the hub.
-	time.Sleep(100 * time.Millisecond)
+	// The echo round-trip above proves the connection is registered in the hub.
 
 	// Kick the connection.
 	r := controlPost(t, controlURL, "/kick?id=kick-1")
@@ -196,14 +229,8 @@ func TestShutdown(t *testing.T) {
 		t.Fatalf("shutdown: %s", r.Error)
 	}
 
-	// Wait for listener to close.
-	time.Sleep(100 * time.Millisecond)
-
-	// New dials should fail.
-	_, _, err := websocket.DefaultDialer.Dial(wsURL+"?id=sd-2", nil)
-	if err == nil {
-		t.Fatal("expected dial to fail after shutdown")
-	}
+	// Wait for listener to close — poll until dial fails.
+	waitForDialFail(t, wsURL)
 
 	// Control port should still be alive.
 	status := controlGet(t, controlURL, "/health")
@@ -235,13 +262,8 @@ func TestRestart(t *testing.T) {
 		t.Fatalf("shutdown: %s", r.Error)
 	}
 
-	time.Sleep(100 * time.Millisecond)
-
-	// Verify dials fail.
-	_, _, err := websocket.DefaultDialer.Dial(wsURL+"?id=rs-1", nil)
-	if err == nil {
-		t.Fatal("expected dial to fail after shutdown")
-	}
+	// Wait for listener to close — poll until dial fails.
+	waitForDialFail(t, wsURL)
 
 	// Restart.
 	r = controlPost(t, controlURL, "/restart")
@@ -249,7 +271,8 @@ func TestRestart(t *testing.T) {
 		t.Fatalf("restart: %s", r.Error)
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait for server to be ready — poll until dial succeeds.
+	waitForDialSuccess(t, wsURL)
 
 	// Verify WS is serving again on the same port.
 	conn := dialWS(t, wsURL, "id=rs-2")
@@ -276,7 +299,8 @@ func TestRestart_WhileRunning(t *testing.T) {
 		t.Fatalf("restart: %s", r.Error)
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait for server to be ready — poll until dial succeeds.
+	waitForDialSuccess(t, wsURL)
 
 	// Verify WS is serving.
 	conn := dialWS(t, wsURL, "id=rr-1")
@@ -330,13 +354,13 @@ func TestShutdownRestart_KickAfterRestart(t *testing.T) {
 
 	// Shutdown and restart.
 	controlPost(t, controlURL, "/shutdown")
-	time.Sleep(100 * time.Millisecond)
+	waitForDialFail(t, wsURL)
 
 	r := controlPost(t, controlURL, "/restart")
 	if !r.OK {
 		t.Fatalf("restart: %s", r.Error)
 	}
-	time.Sleep(100 * time.Millisecond)
+	waitForDialSuccess(t, wsURL)
 
 	// Connect and then kick.
 	conn := dialWS(t, wsURL, "id=srk-1")
@@ -463,8 +487,13 @@ func TestConcurrentEcho(t *testing.T) {
 	}
 
 	for range clients {
-		if err := <-errs; err != nil {
-			t.Error(err)
+		select {
+		case err := <-errs:
+			if err != nil {
+				t.Error(err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for concurrent echo client to finish")
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Replace `time.Sleep(100ms)` with deterministic polling helpers in tests to eliminate timing-dependent failures. Resolves wspulse/.github#18 (testserver portion).

## Changes

- Add `waitForDialFail` / `waitForDialSuccess` polling helpers with 3s deadline
- Replace 7 `time.Sleep(100ms)` calls for shutdown/restart sync with polling helpers
- Remove redundant sleep in TestKick (echo round-trip already proves registration)
- Wrap bare `<-errs` receive in TestConcurrentEcho with select + timeout

Note: `TestFrameRoundTrip` failure is pre-existing on develop (Frame.ID stripped by core — tracked in wspulse/.github#11).

## Checklist

### Required

- [x] `make check` passes (excluding pre-existing TestFrameRoundTrip failure)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR