### PR TITLE
fix: remove Frame.ID from round-trip test

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -392,7 +392,6 @@ func TestFrameRoundTrip(t *testing.T) {
 	conn := dialWS(t, wsURL, "id=rt-1")
 
 	outbound := map[string]any{
-		"id":      "msg-001",
 		"event":   "chat.message",
 		"payload": map[string]any{"user": "alice", "text": "hello"},
 	}
@@ -405,9 +404,6 @@ func TestFrameRoundTrip(t *testing.T) {
 		t.Fatalf("read: %v", err)
 	}
 
-	if got["id"] != "msg-001" {
-		t.Errorf("id: want %q, got %q", "msg-001", got["id"])
-	}
 	if got["event"] != "chat.message" {
 		t.Errorf("event: want %q, got %q", "chat.message", got["event"])
 	}


### PR DESCRIPTION
## Summary

Fix `TestFrameRoundTrip` which was broken after Frame.ID removal (wspulse/.github#9). The test still asserted the `id` field was preserved in the echo response, but `Frame` no longer has an `ID` field — the server codec strips it during decode.

## Changes

- Removed `"id": "msg-001"` from the outbound JSON in `TestFrameRoundTrip`
- Removed the `got["id"]` assertion
- Test now verifies only `event` and `payload` round-trip, which are the actual Frame fields

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR