### PR TITLE
chore: update server dependency to v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/stretchr/testify v1.11.1
-	github.com/wspulse/server v0.6.0
+	github.com/wspulse/server v0.8.0
 	go.uber.org/zap v1.27.1
 )
 
@@ -13,7 +13,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/wspulse/core v0.2.0 // indirect
+	github.com/wspulse/core v0.3.1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wspulse/core v0.2.0 h1:1Tyd2OZ2KMi+qvmf5PKxP7KDzCfT09Jx6KRUrDEXlCg=
-github.com/wspulse/core v0.2.0/go.mod h1:IT/dOeC+Hwh+CT6rI7YVI1CKdVmbd4tbpF6ggztXl8M=
-github.com/wspulse/server v0.6.0 h1:oHNY1auxv1bKtNSdB2NmBqYVxjR/I/OD+w/uNsbmHZY=
-github.com/wspulse/server v0.6.0/go.mod h1:BIncijHx5IbPkPCZfO3P5Hye3o2jWWQ352TKMDnkkvU=
+github.com/wspulse/core v0.3.1 h1:IPcFmNoX9or0rCqr7sRuDTfxLU8X+9bXoonlxVG4hFM=
+github.com/wspulse/core v0.3.1/go.mod h1:ZJxv16MeEIcq9z3Wo2fmz3P+qSz3IA28nuoTYk8pYC0=
+github.com/wspulse/server v0.8.0 h1:eL6Q3Du2urELZdi0NBUHKnD1242lUN8GKg9HfABCRzU=
+github.com/wspulse/server v0.8.0/go.mod h1:9jjKIh8SVIOEar0B0prBoaz9fSGHmjKITnuQDn/08Gs=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ type testServer struct {
 	logger *zap.Logger
 
 	mu         sync.Mutex
-	server     wspulse.Server
+	server     wspulse.Hub
 	wsListener net.Listener
 	wsPort     int // fixed port for restart
 	wsServing  chan struct{}
@@ -74,8 +74,8 @@ func newTestServer(logger *zap.Logger) *testServer {
 	return &testServer{logger: logger}
 }
 
-func (ts *testServer) newWSServer() wspulse.Server {
-	return wspulse.NewServer(
+func (ts *testServer) newWSServer() wspulse.Hub {
+	return wspulse.NewHub(
 		func(r *http.Request) (roomID, connectionID string, err error) {
 			if r.URL.Query().Get("reject") == "1" {
 				return "", "", fmt.Errorf("rejected by test server")
@@ -255,7 +255,7 @@ func (ts *testServer) handleRestart(w http.ResponseWriter, _ *http.Request) {
 
 // wrapHandler intercepts ?ignore_pings=1 connections before they reach the
 // wspulse server. All other requests are forwarded to srv.
-func (ts *testServer) wrapHandler(srv wspulse.Server) http.Handler {
+func (ts *testServer) wrapHandler(srv wspulse.Hub) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("ignore_pings") == "1" {
 			ts.handleIgnorePings(w, r)


### PR DESCRIPTION
## Summary

Update server dependency to v0.8.0 and migrate renamed symbols (`Server` → `Hub`, `NewServer` → `NewHub`).

## Related issues

Closes #7
Relates to wspulse/.github#23

## Changes

- Bumped `github.com/wspulse/server` from v0.6.0 to v0.8.0
- Renamed `wspulse.Server` → `wspulse.Hub` (3 occurrences in `main.go`)
- Renamed `wspulse.NewServer()` → `wspulse.NewHub()` (1 occurrence in `main.go`)

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR