### PR TITLE
chore: migrate import path to github.com/wspulse/hub

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-wspulse/testserver is a **shared test server** for non-Go wspulse client integration tests. It exposes two local ports: a WebSocket echo server (via `wspulse/server`) and an HTTP control API for test orchestration. Module path: `github.com/wspulse/testserver`. Package name: `main`. Depends on `github.com/wspulse/server`.
+wspulse/testserver is a **shared test server** for non-Go wspulse client integration tests. It exposes two local ports: a WebSocket echo server (via `wspulse/hub`) and an HTTP control API for test orchestration. Module path: `github.com/wspulse/testserver`. Package name: `main`. Depends on `github.com/wspulse/hub`.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,10 @@ Shared integration test server for non-Go wspulse client integration tests. Read
 
 `testserver` is a standalone Go `main` binary (`github.com/wspulse/testserver`) that exposes two local TCP ports:
 
-- **WebSocket port** — echo server backed by `wspulse/server`. Behaviour is controlled by URL query parameters.
+- **WebSocket port** — echo server backed by `wspulse/hub`. Behaviour is controlled by URL query parameters.
 - **Control port** — HTTP API for test orchestration (`/health`, `/kick`, `/shutdown`, `/restart`).
 
-On startup it prints `READY:<ws_port>:<control_port>` to stderr; client test harnesses parse this line to discover both ports. Depends on `github.com/wspulse/server`.
+On startup it prints `READY:<ws_port>:<control_port>` to stderr; client test harnesses parse this line to discover both ports. Depends on `github.com/wspulse/hub`.
 
 ## File Index
 
@@ -26,7 +26,7 @@ On startup it prints `READY:<ws_port>:<control_port>` to stderr; client test har
 | `?reject=1`    | `ConnectFunc` returns an error → HTTP 401                           |
 | `?room=<id>`   | Assigns connection to room `<id>` (default: `"test"`)               |
 | `?id=<id>`     | Sets `connectionID` (default: auto-generated UUID)                  |
-| `?ignore_pings=1` | Bypasses wspulse/server; raw echo that suppresses Pong replies   |
+| `?ignore_pings=1` | Bypasses wspulse/hub; raw echo that suppresses Pong replies   |
 
 ## Development Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@
 
 ### Changed
 
-- Bumped `wspulse/server` dependency from v0.3.0 to v0.6.0
+- Bumped `wspulse/hub` dependency from v0.3.0 to v0.6.0
 
 ### Added
 
-- `wspulse/server` version badge in README
+- `wspulse/hub` version badge in README
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ git clone https://github.com/wspulse/testserver
 cd testserver
 # Clone core and server alongside testserver (required for local development)
 git clone https://github.com/wspulse/core ../core
-git clone https://github.com/wspulse/server ../server
+git clone https://github.com/wspulse/hub ../server
 go mod tidy
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wspulse/testserver
 
 [![CI](https://github.com/wspulse/testserver/actions/workflows/ci.yml/badge.svg)](https://github.com/wspulse/testserver/actions/workflows/ci.yml)
-[![wspulse/server](https://img.shields.io/badge/wspulse%2Fserver-v0.6.0-blue)](https://github.com/wspulse/server/releases/tag/v0.6.0)
+[![wspulse/hub](https://img.shields.io/badge/wspulse%2Fserver-v0.6.0-blue)](https://github.com/wspulse/hub/releases/tag/v0.6.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Shared test server for wspulse non-Go client integration tests. Provides a WebSocket echo server with an HTTP control API for test orchestration.
@@ -12,7 +12,7 @@ Shared test server for wspulse non-Go client integration tests. Provides a WebSo
 
 ## Why
 
-client-go tests reconnect/heartbeat scenarios by embedding `wspulse/server` in-process. Non-Go clients (Kotlin, TypeScript, Swift) run the server as an external process and need a way to trigger server-side actions (kick connections, shut down, restart) from their test harnesses.
+client-go tests reconnect/heartbeat scenarios by embedding `wspulse/hub` in-process. Non-Go clients (Kotlin, TypeScript, Swift) run the server as an external process and need a way to trigger server-side actions (kick connections, shut down, restart) from their test harnesses.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/stretchr/testify v1.11.1
-	github.com/wspulse/server v0.6.0
+	github.com/wspulse/hub v0.8.1
 	go.uber.org/zap v1.27.1
 )
 
@@ -13,7 +13,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/wspulse/core v0.2.0 // indirect
+	github.com/wspulse/core v0.3.1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wspulse/core v0.2.0 h1:1Tyd2OZ2KMi+qvmf5PKxP7KDzCfT09Jx6KRUrDEXlCg=
-github.com/wspulse/core v0.2.0/go.mod h1:IT/dOeC+Hwh+CT6rI7YVI1CKdVmbd4tbpF6ggztXl8M=
-github.com/wspulse/server v0.6.0 h1:oHNY1auxv1bKtNSdB2NmBqYVxjR/I/OD+w/uNsbmHZY=
-github.com/wspulse/server v0.6.0/go.mod h1:BIncijHx5IbPkPCZfO3P5Hye3o2jWWQ352TKMDnkkvU=
+github.com/wspulse/core v0.3.1 h1:IPcFmNoX9or0rCqr7sRuDTfxLU8X+9bXoonlxVG4hFM=
+github.com/wspulse/core v0.3.1/go.mod h1:ZJxv16MeEIcq9z3Wo2fmz3P+qSz3IA28nuoTYk8pYC0=
+github.com/wspulse/hub v0.8.1 h1:Uk8KNyX8mSIj7Xiwcwz5MU++40aZlqBMu6PowpbkDkA=
+github.com/wspulse/hub v0.8.1/go.mod h1:Yfm3FN/bXl8VqO/g14Cj33RAsAE6Y5++0oYuDljFZ4I=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@
 //     ?room=<id>      → assigns connection to room <id> (default: "test")
 //     ?id=<id>        → sets connectionID (default: auto-generated UUID)
 //     ?ignore_pings=1 → raw echo handler that suppresses Pong replies
-//     (bypasses wspulse/server; used to test pong-timeout)
+//     (bypasses wspulse/hub; used to test pong-timeout)
 //
 //   - Control port — HTTP API for test orchestration:
 //     GET  /health   → 200 OK
@@ -31,7 +31,7 @@ import (
 	"github.com/gorilla/websocket"
 	"go.uber.org/zap"
 
-	wspulse "github.com/wspulse/server"
+	wspulse "github.com/wspulse/hub"
 )
 
 func main() {
@@ -64,7 +64,7 @@ type testServer struct {
 	logger *zap.Logger
 
 	mu         sync.Mutex
-	server     wspulse.Server
+	server     wspulse.Hub
 	wsListener net.Listener
 	wsPort     int // fixed port for restart
 	wsServing  chan struct{}
@@ -74,8 +74,8 @@ func newTestServer(logger *zap.Logger) *testServer {
 	return &testServer{logger: logger}
 }
 
-func (ts *testServer) newWSServer() wspulse.Server {
-	return wspulse.NewServer(
+func (ts *testServer) newWSServer() wspulse.Hub {
+	return wspulse.NewHub(
 		func(r *http.Request) (roomID, connectionID string, err error) {
 			if r.URL.Query().Get("reject") == "1" {
 				return "", "", fmt.Errorf("rejected by test server")
@@ -255,7 +255,7 @@ func (ts *testServer) handleRestart(w http.ResponseWriter, _ *http.Request) {
 
 // wrapHandler intercepts ?ignore_pings=1 connections before they reach the
 // wspulse server. All other requests are forwarded to srv.
-func (ts *testServer) wrapHandler(srv wspulse.Server) http.Handler {
+func (ts *testServer) wrapHandler(srv wspulse.Hub) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("ignore_pings") == "1" {
 			ts.handleIgnorePings(w, r)


### PR DESCRIPTION
## Summary

Migrate the testserver module from `github.com/wspulse/server` to `github.com/wspulse/hub` (v0.8.1), following the upstream repo rename. This includes the import path change, type renames (`Server` -> `Hub`, `NewServer` -> `NewHub`), and all markdown reference updates.

## Related issues

Relates to wspulse/.github#23

## Changes

- `go.mod`: replaced `github.com/wspulse/server v0.6.0` with `github.com/wspulse/hub v0.8.1` (also bumps transitive dep `core` v0.2.0 -> v0.3.1)
- `main.go`: updated import path from `github.com/wspulse/server` to `github.com/wspulse/hub`; renamed `wspulse.Server` -> `wspulse.Hub`, `wspulse.NewServer` -> `wspulse.NewHub`; updated comments referencing `wspulse/server`
- `README.md`: updated all references and badge from `wspulse/server` to `wspulse/hub`
- `CHANGELOG.md`: updated historical references from `wspulse/server` to `wspulse/hub`
- `CONTRIBUTING.md`: updated clone instructions from `wspulse/server` to `wspulse/hub`
- `AGENTS.md`: updated all references from `wspulse/server` to `wspulse/hub`
- `.github/copilot-instructions.md`: updated all references from `wspulse/server` to `wspulse/hub`

## Checklist

### Required

- [x] `make check` passes (`fmt` -> `lint` -> `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `.github/instructions/commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR